### PR TITLE
Roasting and Constrainment task fix

### DIFF
--- a/ansible/roles/windows_domain_controller/tasks/set_constrainment.yml
+++ b/ansible/roles/windows_domain_controller/tasks/set_constrainment.yml
@@ -1,11 +1,11 @@
 - name: unconstrained user unconstrained delegation set
   win_shell: |
-    $user = (Get-ADUser -Identity "Unconstrained User").DistinguishedName
+    $user = (Get-ADUser -Identity "Unconstrained.User").DistinguishedName
     Set-ADAccountControl -Identity $user -TrustedForDelegation $True
   register: unconstrained_delegation_set
 
 - name: constrained user set constrained delegation
   win_shell: |
-    $user = (Get-ADUser -Identity "Constrained User").DistinguishedName
+    $user = (Get-ADUser -Identity "Constrained.User").DistinguishedName
     Set-ADObject -Identity $user -Add @{"msDS-AllowedToDelegateTo" = @("CIFS/dc01","CIFS/dc01.{{ root_domain }}","CIFS/dc01.{{ root_domain }}/{{ root_domain }}")}
   register: constrained_delegation_set

--- a/ansible/roles/windows_domain_controller/tasks/set_roasting.yml
+++ b/ansible/roles/windows_domain_controller/tasks/set_roasting.yml
@@ -2,12 +2,12 @@
 # Alternative KerberosEncryptionTypes are AES128 and AES256
 - name: Set Kerberoastable user SPN & Encryption Type
   win_shell: |
-    $user = (Get-ADUser -Identity "Kerberoast Me").DistinguishedName
+    $user = (Get-ADUser -Identity "Kerberoast.Me").DistinguishedName
     Set-ADUser -Identity $user -ServicePrincipalNames @{Add='Kerberoast Me/{{ root_domain }}'}
     Set-ADUser -Identity $user -KerberosEncryptionType RC4
 
 # thanks to Andrew Schwartz (@4ndr3ew6S) for this Powershell
 - name: Set DoesNotRequirePreAuth for AS-Rep Roasting
   win_shell: |
-    $user = (Get-ADUser -Identity "AsrepRoast Me").DistinguishedName
+    $user = (Get-ADUser -Identity "AsrepRoast.Me").DistinguishedName
     Set-ADAccountControl -Identity $user -DoesNotRequirePreAuth $True


### PR DESCRIPTION
Updating both tasks to use `FName.LName` format rather than `FName LName`.